### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/marceljk/gym-tracker-web/security/code-scanning/3](https://github.com/marceljk/gym-tracker-web/security/code-scanning/3)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token access by default.

Best fix here: insert at the top level (after `on:` block, before `jobs:`):

```yml
permissions:
  contents: read
```

Why this is best:
- It resolves the CodeQL finding for all jobs at once.
- It preserves existing workflow functionality (checkout/build/test need contents read).
- It documents intended token scope and prevents accidental privilege expansion if defaults change.

No imports/methods/dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
